### PR TITLE
Add HIPAA regex detector package and master classifier

### DIFF
--- a/hippa_master.py
+++ b/hippa_master.py
@@ -1,0 +1,49 @@
+"""Master dispatcher for HIPAA-style regex detectors over single words."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Dict, Literal
+
+from hippa_regex import DISCOVERED
+
+Flag = Literal["sensitive", "non-sensitive"]
+
+
+def classify_word(word: str) -> Dict[str, Flag]:
+    """Run `word` through every detector and return a map of identifier to flag."""
+    results: Dict[str, Flag] = {}
+    for identifier in sorted(DISCOVERED.keys()):
+        module = DISCOVERED[identifier]
+        try:
+            matched = bool(module.detect(word))  # type: ignore[attr-defined]
+        except Exception:
+            matched = False
+        results[identifier] = "sensitive" if matched else "non-sensitive"
+    return results
+
+
+def _run_cli(args: list[str]) -> None:
+    if args:
+        output = classify_word(args[0])
+        print(json.dumps(output, sort_keys=False))
+        return
+
+    samples = [
+        "john",
+        "GENEVA",
+        "12/05",
+        "+41791234567",
+        "john@example.org",
+        "123-45-6789",
+        "1HGCM82633A004352",
+        "192.168.0.1",
+        "https://example.com",
+    ]
+    summary = {token: classify_word(token) for token in samples}
+    print(json.dumps(summary, sort_keys=False, indent=2))
+
+
+if __name__ == "__main__":
+    _run_cli(sys.argv[1:])

--- a/hippa_regex/__init__.py
+++ b/hippa_regex/__init__.py
@@ -1,0 +1,26 @@
+"""Dynamic discovery of HIPAA-style regex detectors."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from pkgutil import iter_modules
+from typing import Dict, Any
+
+DISCOVERED: Dict[str, Any] = {}
+
+_package_path = Path(__file__).resolve().parent
+
+for module_info in iter_modules([str(_package_path)]):
+    name = module_info.name
+    if name in {"__init__", "base"}:
+        continue
+    module = import_module(f"{__name__}.{name}")
+    identifier = getattr(module, "IDENTIFIER", None)
+    detect = getattr(module, "detect", None)
+    details = getattr(module, "details", None)
+    if not identifier or not callable(detect) or not callable(details):
+        continue
+    DISCOVERED[identifier] = module
+
+__all__ = ["DISCOVERED"]

--- a/hippa_regex/account_numbers.py
+++ b/hippa_regex/account_numbers.py
@@ -1,0 +1,40 @@
+"""Detector for generic account number heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "account_numbers"
+DESCRIPTION = "Financial or other account numbers represented by long tokens."
+
+PATTERNS: list[re.Pattern] = [
+    # Long digit-only tokens such as 12345678
+    re.compile(r"^\d{8,}\Z", re.IGNORECASE),
+    # Mixed alphanumeric tokens requiring both letters and digits
+    re.compile(r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9]{8,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: Specific account formats vary widely across institutions.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/base.py
+++ b/hippa_regex/base.py
@@ -1,0 +1,18 @@
+"""Typing protocol for HIPAA detector modules."""
+
+from __future__ import annotations
+
+from typing import Protocol, Dict, Any
+
+
+class Detector(Protocol):
+    """Protocol describing the public API exposed by detector modules."""
+
+    IDENTIFIER: str
+    DESCRIPTION: str
+
+    def detect(self, word: str) -> bool:
+        """Return True when the provided word matches the identifier."""
+
+    def details(self, word: str) -> Dict[str, Any]:
+        """Return debugging information for the detection attempt."""

--- a/hippa_regex/biometric_identifiers.py
+++ b/hippa_regex/biometric_identifiers.py
@@ -1,0 +1,30 @@
+"""Detector stub for biometric identifiers (not regex-detectable)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "biometric_identifiers"
+DESCRIPTION = "Biometric identifiers such as fingerprints or voiceprints (not regexable)."
+
+PATTERNS: list[re.Pattern] = []
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    _clean(word)
+    return False
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    _clean(word)
+    # TODO: Requires multimodal analysis beyond regex.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/certificate_license_numbers.py
+++ b/hippa_regex/certificate_license_numbers.py
@@ -1,0 +1,38 @@
+"""Detector for certificate or license number heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "certificate_license_numbers"
+DESCRIPTION = "Professional certificate or license numbers with mixed characters."
+
+PATTERNS: list[re.Pattern] = [
+    # Example: ABC-12345 or RN123456
+    re.compile(r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9-]{6,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: State-specific license formats may include prefixes or suffixes.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/dates_except_year.py
+++ b/hippa_regex/dates_except_year.py
@@ -1,0 +1,39 @@
+"""Detector for dates excluding standalone years."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "dates_except_year"
+DESCRIPTION = "Date expressions without four-digit years (e.g., 12/05, jan)."
+
+PATTERNS: list[re.Pattern] = [
+    # Numeric day/month combos: 12/05, 1-2, 03.14
+    re.compile(r"^(?:0?[1-9]|[12][0-9]|3[01])[-/.](?:0?[1-9]|1[0-2])\Z", re.IGNORECASE),
+    # Month abbreviations excluding common words like 'may'
+    re.compile(r"^(jan|feb|mar|apr|jun|jul|aug|sep|sept|oct|nov|dec)\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/device_identifiers.py
+++ b/hippa_regex/device_identifiers.py
@@ -1,0 +1,38 @@
+"""Detector for device identifier heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "device_identifiers"
+DESCRIPTION = "Medical device identifiers approximated via serial-like tokens."
+
+PATTERNS: list[re.Pattern] = [
+    # Example: A12B-34CD or SN12345678
+    re.compile(r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z0-9-]{8,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: Device identifiers frequently include structured delimiters.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/email_addresses.py
+++ b/hippa_regex/email_addresses.py
@@ -1,0 +1,36 @@
+"""Detector for email address tokens."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "email_addresses"
+DESCRIPTION = "Email addresses using conservative local@domain heuristics."
+
+PATTERNS: list[re.Pattern] = [
+    re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/fax_numbers.py
+++ b/hippa_regex/fax_numbers.py
@@ -1,0 +1,39 @@
+"""Detector for fax-number-like tokens (mirrors phone detection)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "fax_numbers"
+DESCRIPTION = "Fax numbers share phone number formatting heuristics."
+
+PATTERNS: list[re.Pattern] = [
+    # Compact formats resembling international numbers.
+    re.compile(r"^\+?\d{7,15}\Z", re.IGNORECASE),
+    # Grouped national patterns such as 044-123-4567 or (123)456-7890
+    re.compile(r"^\(?(?:\d{2,4})\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/full_face_photos.py
+++ b/hippa_regex/full_face_photos.py
@@ -1,0 +1,30 @@
+"""Detector stub for full-face photographic images."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "full_face_photos"
+DESCRIPTION = "Full-face photographs cannot be detected from text tokens."
+
+PATTERNS: list[re.Pattern] = []
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    _clean(word)
+    return False
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    _clean(word)
+    # TODO: Requires image analysis outside the scope of regex heuristics.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/geo_subdivisions.py
+++ b/hippa_regex/geo_subdivisions.py
@@ -1,0 +1,40 @@
+"""Detector for limited geographic subdivisions such as postal codes."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "geo_subdivisions"
+DESCRIPTION = "Geographic subdivisions detectable via postal code heuristics."
+
+PATTERNS: list[re.Pattern] = [
+    # US ZIP codes (12345 or 12345-6789)
+    re.compile(r"^\d{5}(?:-\d{4})?\Z", re.IGNORECASE),
+    # Swiss-style 4-digit postal codes avoiding leading zero.
+    re.compile(r"^[1-9]\d{3}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: City and street names require richer context than a single token.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/health_plan_beneficiary_numbers.py
+++ b/hippa_regex/health_plan_beneficiary_numbers.py
@@ -1,0 +1,38 @@
+"""Detector for health plan beneficiary number heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "health_plan_beneficiary_numbers"
+DESCRIPTION = "Health plan beneficiary numbers treated as long mixed tokens."
+
+PATTERNS: list[re.Pattern] = [
+    # Example: AB123456789 or 1234567890
+    re.compile(r"^(?=.*\d)[A-Za-z0-9]{9,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: Benefit IDs can include separators and institution-specific prefixes.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/ip_addresses.py
+++ b/hippa_regex/ip_addresses.py
@@ -1,0 +1,56 @@
+"""Detector for IPv4 and IPv6 addresses."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "ip_addresses"
+DESCRIPTION = "IP addresses covering IPv4 dotted quads and common IPv6 forms."
+
+_IPV6_PATTERN = (
+    r"^(?:(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}|"
+    r"(?:[A-F0-9]{1,4}:){1,7}:|"
+    r":(?:[A-F0-9]{1,4}:){1,7}|"
+    r"(?:[A-F0-9]{1,4}:){1,6}:[A-F0-9]{1,4}|"
+    r"(?:[A-F0-9]{1,4}:){1,5}(?::[A-F0-9]{1,4}){1,2}|"
+    r"(?:[A-F0-9]{1,4}:){1,4}(?::[A-F0-9]{1,4}){1,3}|"
+    r"(?:[A-F0-9]{1,4}:){1,3}(?::[A-F0-9]{1,4}){1,4}|"
+    r"(?:[A-F0-9]{1,4}:){1,2}(?::[A-F0-9]{1,4}){1,5}|"
+    r"[A-F0-9]{1,4}:(?::[A-F0-9]{1,4}){1,6}|"
+    r":(?::[A-F0-9]{1,4}){1,7}|"
+    r"::)\Z"
+)
+
+PATTERNS: list[re.Pattern] = [
+    # IPv4 dotted decimal (e.g., 192.168.0.1)
+    re.compile(
+        r"^(?:(?:25[0-5]|2[0-4]\d|1?\d?\d)\.){3}(?:25[0-5]|2[0-4]\d|1?\d?\d)\Z",
+        re.IGNORECASE,
+    ),
+    # IPv6 (includes compressed forms)
+    re.compile(_IPV6_PATTERN, re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/medical_record_numbers.py
+++ b/hippa_regex/medical_record_numbers.py
@@ -1,0 +1,38 @@
+"""Detector for medical record number heuristics."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "medical_record_numbers"
+DESCRIPTION = "Medical record numbers heuristically treated as long digit strings."
+
+PATTERNS: list[re.Pattern] = [
+    # Example: 123456 or 000123456789
+    re.compile(r"^\d{6,}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # TODO: Many institutions use alphanumeric or formatted MRNs.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/names.py
+++ b/hippa_regex/names.py
@@ -1,0 +1,30 @@
+"""Detector stub for personal names (not regex-detectable)."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "names"
+DESCRIPTION = "Personal names (not reliably detectable via regex in a single token)."
+
+PATTERNS: list[re.Pattern] = []
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    _clean(word)
+    return False
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    _clean(word)
+    # TODO: Requires contextual NLP to identify personal names.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/other_unique_identifiers.py
+++ b/hippa_regex/other_unique_identifiers.py
@@ -1,0 +1,30 @@
+"""Detector stub for miscellaneous unique identifiers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "other_unique_identifiers"
+DESCRIPTION = "Other unique identifiers that require contextual analysis."
+
+PATTERNS: list[re.Pattern] = []
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    _clean(word)
+    return False
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    _clean(word)
+    # TODO: Define case-specific heuristics for additional identifier categories.
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/phone_numbers.py
+++ b/hippa_regex/phone_numbers.py
@@ -1,0 +1,39 @@
+"""Detector for phone-number-like tokens."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "phone_numbers"
+DESCRIPTION = "Telephone numbers, including international and dashed formats."
+
+PATTERNS: list[re.Pattern] = [
+    # Compact international style: +41791234567 or 0791234567
+    re.compile(r"^\+?\d{7,15}\Z", re.IGNORECASE),
+    # Grouped national patterns: (123) 456-7890, 044-123-4567
+    re.compile(r"^\(?(?:\d{2,4})\)?[\s.-]?\d{3,4}[\s.-]?\d{3,4}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/ssn_numbers.py
+++ b/hippa_regex/ssn_numbers.py
@@ -1,0 +1,39 @@
+"""Detector for U.S. Social Security numbers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "ssn_numbers"
+DESCRIPTION = "United States Social Security numbers with simple invalid-range guards."
+
+PATTERNS: list[re.Pattern] = [
+    re.compile(
+        r"^(?!000|666|9\d\d)\d{3}[- ]?(?!00)\d{2}[- ]?(?!0000)\d{4}\Z",
+        re.IGNORECASE,
+    ),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/urls.py
+++ b/hippa_regex/urls.py
@@ -1,0 +1,39 @@
+"""Detector for web URLs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "urls"
+DESCRIPTION = "Web URLs with optional scheme and simple domain heuristics."
+
+PATTERNS: list[re.Pattern] = [
+    re.compile(
+        r"^(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?:/[^\s]*)?\Z",
+        re.IGNORECASE,
+    ),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    return {"matched": False, "pattern": None}

--- a/hippa_regex/vehicle_identifiers.py
+++ b/hippa_regex/vehicle_identifiers.py
@@ -1,0 +1,37 @@
+"""Detector for vehicle identifiers such as VINs."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+IDENTIFIER = "vehicle_identifiers"
+DESCRIPTION = "Vehicle identifiers focused on 17-character VIN patterns."
+
+PATTERNS: list[re.Pattern] = [
+    re.compile(r"^[A-HJ-NPR-Z0-9]{17}\Z", re.IGNORECASE),
+]
+
+_STRIP_CHARS = " \t\n\r\f\v\"'.,;:!?()[]{}<>"
+
+
+def _clean(word: str) -> str:
+    return word.strip(_STRIP_CHARS)
+
+
+def detect(word: str) -> bool:
+    """Return True if `word` matches this identifier by regex (single-token heuristic)."""
+    cleaned = _clean(word)
+    if not cleaned:
+        return False
+    return any(pattern.fullmatch(cleaned) for pattern in PATTERNS)
+
+
+def details(word: str) -> Dict[str, Any]:
+    """Return debugging info for the detection attempt."""
+    cleaned = _clean(word)
+    for pattern in PATTERNS:
+        if pattern.fullmatch(cleaned):
+            return {"matched": True, "pattern": pattern.pattern}
+    # Example: details("1HGCM82633A004352") -> {"matched": True, ...}
+    return {"matched": False, "pattern": None}


### PR DESCRIPTION
## Summary
- add a `hippa_regex` package containing per-identifier detector modules with shared APIs
- implement dynamic discovery to expose detectors and wire them into a master classifier CLI

## Testing
- python hippa_master.py john@example.org
- python hippa_master.py


------
https://chatgpt.com/codex/tasks/task_e_68dcdc4fae8083289104d9a4100b2eb3